### PR TITLE
Only import what's needed from RxJS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@ionic/cloud';
 
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromEventPattern';
 import { Injectable, ModuleWithProviders, NgModule, OpaqueToken } from '@angular/core';
 import {
   Auth as _Auth,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from '@ionic/cloud';
 
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import { Injectable, ModuleWithProviders, NgModule, OpaqueToken } from '@angular/core';
 import {
   Auth as _Auth,


### PR DESCRIPTION
As documented here: https://github.com/ReactiveX/rxjs#es6-via-npm

This saves a LOT of kb's in our builds.