### PR TITLE
fix(core): change 'OpaqueToken' to 'InjectionToken'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export * from '@ionic/cloud';
 
 import { Observable } from 'rxjs';
-import { Injectable, ModuleWithProviders, NgModule, OpaqueToken } from '@angular/core';
+import { Injectable, ModuleWithProviders, NgModule, InjectionToken } from '@angular/core';
 import {
   Auth as _Auth,
   FacebookAuth as _FacebookAuth,
@@ -85,7 +85,7 @@ export class Push extends _Push implements IPush {
 @Injectable()
 export class User extends _User {}
 
-export const CloudSettingsToken = new OpaqueToken('CloudSettings');
+export const CloudSettingsToken = new InjectionToken('CloudSettings');
 
 export function provideContainer(settings: CloudSettings): DIContainer {
   let container = new DIContainer();


### PR DESCRIPTION
BREAKING CHANGE: OpaqueToken has been removed as it was deprecated since v4. Use InjectionToken instead.

fixed #63 [#13385](https://github.com/ionic-team/ionic/issues/13385)